### PR TITLE
TileEditor fixes

### DIFF
--- a/TileEditor/TileGraphicsEditor.cs
+++ b/TileEditor/TileGraphicsEditor.cs
@@ -56,6 +56,8 @@ public class TileGraphicsEditor : VBoxContainer
     List<string> _modelGroups = new List<string>();
     Dictionary<string, bool> _groupAssigned = new System.Collections.Generic.Dictionary<string, bool>();
     Dictionary<string, Vector3> _groupAveragePosition = new Dictionary<string, Vector3>();
+
+    int _graphicsRotation = 0;
     void AssignableSelected(int indx)
     {
         if (!_loaded)
@@ -355,8 +357,9 @@ public class TileGraphicsEditor : VBoxContainer
     {
         _tileLogicOverlay.Opacity = val / (float)_logicOpacitySlider.MaxValue;
     }
-    void SetGroupPositionRotations(int rot)
+    void RotateGroupPositions(int rot)
     {
+        _graphicsRotation += rot;
         float r = ((float)PI / 2) * (float)rot;
         foreach (var it in _groupAveragePosition.Keys.ToList())
         {
@@ -365,18 +368,19 @@ public class TileGraphicsEditor : VBoxContainer
     }
     void SetRotation(int rot)
     {
+        RotateGroupPositions(-_graphicsRotation);
+        rot = _config.Rotation = (rot) % GameEngine.N_SIDES;
         float r = ((float)PI / 2) * (float)rot;
         _modelRoot.Rotation = new Vector3(0, 0, 0);
         _modelRoot.Rotate(Vector3.Up, r);
-        SetGroupPositionRotations(_config.Rotation);
+        RotateGroupPositions(rot);
     }
     void RotatePressed()
     {
         Assert(_modelRoot != null);
         Assert(_config != null);
 
-        _config.Rotation = (_config.Rotation + 1) % GameEngine.N_SIDES;
-        SetRotation(_config.Rotation);
+        SetRotation(_config.Rotation+1);
     }
     void AddModelPressed()
     {

--- a/TileEditor/TileLogicEditor.cs
+++ b/TileEditor/TileLogicEditor.cs
@@ -70,6 +70,7 @@ public class TileLogicEditor : Control
     ItemList _possibleAttributeList;
     ItemList _currentAttributeList;
 
+    Container _attributeButtonContainer;
     Button _addAttributeButton;
     Button _removeAttributeButton;
     Button _resetAttributeButton;
@@ -226,6 +227,10 @@ public class TileLogicEditor : Control
         _possibleAttributeList.RemoveItem(indx);
         Assert(!Tile.NodeAttributes[sel].Contains((int)na));
         Tile.NodeAttributes[sel].Add((int)na);
+        if(!_currentAttributeList.IsAnythingSelected())
+            _removeAttributeButton.Disabled = true;
+        if(!_possibleAttributeList.IsAnythingSelected())
+            _addAttributeButton.Disabled = true;
         return;
     }
     void RemoveAttributePressed(int indx)
@@ -249,6 +254,10 @@ public class TileLogicEditor : Control
         _possibleAttributeList.AddItem(na.ToString());
         Assert(Tile.NodeAttributes[sel].Contains((int)na));
         Tile.NodeAttributes[sel].Remove((int)na);
+        if(!_currentAttributeList.IsAnythingSelected())
+            _removeAttributeButton.Disabled = true;
+        if(!_possibleAttributeList.IsAnythingSelected())
+            _addAttributeButton.Disabled = true;
         return;
 
     }
@@ -292,13 +301,12 @@ public class TileLogicEditor : Control
     }
     void SetInterfaceActive(bool b)
     {
-        foreach (var it in _toolboxContainer.GetChildren())
+        void togglebuttons(Container con)
         {
-            Button button = it as Button;
-            if (button == null)
-                continue;
-            button.Disabled = !b;
+            GetChildrenRecrusively<Button>(con).ForEach(bt => bt.Disabled=!b);
         }
+        togglebuttons(_toolboxContainer);
+        togglebuttons(_attributeButtonContainer);
     }
     void ButtonPressed(int indx)
     {
@@ -631,7 +639,8 @@ public class TileLogicEditor : Control
         _currentAttributeList.Connect("item_selected", this, "CurrentAttributeSelect");
         _currentAttributeList.Connect("nothing_selected", this, "CurrentAttributeDeselect");
         _currentAttributeList.Connect("item_activated", this, "RemoveAttributePressed");
-
+        
+        _attributeButtonContainer = (Container)GetNode("VBoxContainer/BottomHalfContainer/AttributeControlBox");
         _addAttributeButton = (Button)GetNode("VBoxContainer/BottomHalfContainer/AttributeControlBox/AddAttributeButton");
         _removeAttributeButton = (Button)GetNode("VBoxContainer/BottomHalfContainer/AttributeControlBox/RemoveAttributeButton");
         _resetAttributeButton = (Button)GetNode("VBoxContainer/BottomHalfContainer/AttributeControlBox/ResetAttributesbutton");

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=4
 [application]
 
 config/name="Carcassonne"
-run/main_scene="res://Test/Test2D_GUI.tscn"
+run/main_scene="res://TileEditor/TileEditor.tscn"
 config/icon="res://icon.png"
 
 [display]


### PR DESCRIPTION
Fixed TileLogicEditor attribute edition buttons being clickable even when there's no tile loaded
Fixed TileGraphicsEditor's 3D rotations not applying correctly when auto-assigning.